### PR TITLE
Set the aws-lc version tag for the enclave build

### DIFF
--- a/env/enclave/Dockerfile
+++ b/env/enclave/Dockerfile
@@ -45,8 +45,7 @@ RUN mkdir -p /build
 WORKDIR /build
 
 # Build AWS libcrypto
-# TODO: use a tag, once one becomes available.
-ENV AWS_LC_VER=6eabe67472e5e3aa89341d365d5385c3eb6406eb
+ENV AWS_LC_VER="v0.1-beta"
 RUN git clone "https://github.com/awslabs/aws-lc.git" \
     && cd aws-lc \
     && git reset --hard $AWS_LC_VER \


### PR DESCRIPTION
aws-lc tag is now available: https://github.com/awslabs/aws-lc/releases/tag/v0.1-beta

Setting the Dockerfile to use it during the build process instead of the commit sha1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
