### PR TITLE
Fix release build issue when lto enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ members = ["src/vtok_agent", "src/vtok_common", "src/vtok_p11", "src/vtok_rpc", 
 default-members = ["src/vtok_agent", "src/vtok_common", "src/vtok_p11", "src/vtok_rpc", "src/vtok_rand", "src/vtok_srv", "src/vtok_tool", "src/vtok_init"]
 
 [profile.release]
-lto = true
+codegen-units=1


### PR DESCRIPTION
lto=true release builds fail with the internal tooling environment
because of rustc SIGSEGVs. remove lto for now.

Signed-off-by: Bogdan Vasile <bve@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
