### PR TITLE
agent: nginx reload fix

### DIFF
--- a/src/vtok_agent/src/agent/mod.rs
+++ b/src/vtok_agent/src/agent/mod.rs
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 mod mngtok;
 
+use std::collections::HashSet;
+use std::process::Command;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
-use log::{error, info};
-use nix::unistd;
+use log::{debug, error, info, warn};
+use nix::{sys::signal, unistd};
 
 use crate::config;
+use crate::gdata;
 use crate::imds;
-use crate::util;
-use crate::{defs, gdata};
 use crate::{enclave, enclave::P11neEnclave};
 use mngtok::ManagedToken;
 use vtok_rpc::api::schema;
@@ -24,43 +25,48 @@ pub enum Error {
     EnclaveError(enclave::Error),
     RemoveTokenError(schema::ApiError),
     ImdsError(imds::Error),
-    PinGenerationError(std::io::Error),
+    SendSignalError(nix::Error),
+    SystemdExecError(std::io::Error),
+    SystemdParsePidError,
+    SystemdShowPidError(Option<i32>, String),
+    SystemdStartNginxError(Option<i32>),
+    Utf8Error(std::string::FromUtf8Error),
     TokenError(mngtok::Error),
 }
 
 pub struct Agent {
     enclave: Rc<P11neEnclave>,
     tokens: Vec<ManagedToken>,
-    sync_interval: Duration,
+    options: config::Options,
+}
+
+#[derive(Hash, Eq, PartialEq)]
+pub enum PostSyncAction {
+    ReloadNginx,
 }
 
 impl Agent {
     pub fn new(mut config: config::Config) -> Result<Self, Error> {
         let enclave = Rc::new(P11neEnclave::new(config.enclave).map_err(Error::EnclaveError)?);
 
-        let swap_pin = util::generate_pkcs11_pin().map_err(Error::PinGenerationError)?;
         let tokens = config
             .tokens
             .drain(..)
-            .filter_map(
-                |conf| match ManagedToken::new(conf, enclave.clone(), swap_pin.clone()) {
-                    Ok(tok) => Some(tok),
-                    Err(e) => {
-                        error!("Error creating managed token: {:?}", e);
-                        None
-                    }
-                },
-            )
+            .filter_map(|conf| match ManagedToken::new(conf, enclave.clone()) {
+                Ok(tok) => Some(tok),
+                Err(e) => {
+                    error!("Error creating managed token: {:?}", e);
+                    None
+                }
+            })
             .collect();
+
+        debug!("Global options: {:?}", &config.options);
 
         Ok(Self {
             enclave,
             tokens,
-            sync_interval: Duration::from_secs(
-                config
-                    .sync_interval_secs
-                    .unwrap_or(defs::DEFAULT_SYNC_INTERVAL_SECS),
-            ),
+            options: config.options,
         })
     }
 
@@ -70,6 +76,7 @@ impl Agent {
         }
 
         let mut next_sync = Instant::now();
+        let sync_interval = Duration::from_secs(self.options.sync_interval_secs);
 
         loop {
             nix::sys::signal::kill(unistd::Pid::from_raw(self.enclave.pid()), None)
@@ -77,7 +84,7 @@ impl Agent {
 
             if next_sync <= Instant::now() {
                 self.sync()?;
-                next_sync += self.sync_interval;
+                next_sync += sync_interval;
             }
 
             unistd::sleep(1);
@@ -91,6 +98,7 @@ impl Agent {
 
     fn sync(&mut self) -> Result<(), Error> {
         let mut broken_list = Vec::new();
+        let mut post_actions = HashSet::new();
 
         imds::invalidate_cache().map_err(Error::ImdsError)?;
 
@@ -124,13 +132,102 @@ impl Agent {
                         .map_err(Error::RemoveTokenError)?;
                 }
                 Err(e) => return Err(Error::TokenError(e)),
-                Ok(_) => (),
+                Ok(None) => (),
+                Ok(Some(act)) => {
+                    post_actions.insert(act);
+                }
             }
         }
 
+        // Run post-sync actions
+        post_actions
+            .drain()
+            .map(|act| act.execute(&self.options))
+            .count();
+
+        // Remove broken tokens
         self.tokens
             .retain(|tok| broken_list.iter().find(|l| **l == tok.label).is_none());
 
         Ok(())
+    }
+}
+
+impl PostSyncAction {
+    fn execute(&self, options: &config::Options) {
+        match self {
+            Self::ReloadNginx => {
+                Self::reload_nginx(options.nginx_force_start, options.nginx_reload_wait_ms)
+            }
+        }
+    }
+
+    fn reload_nginx(force_start: bool, wait_ms: u64) {
+        info!("Reloading NGINX config");
+        Command::new("systemctl")
+            .args(&["show", "--property=MainPID", "nginx.service"])
+            .output()
+            .map_err(Error::SystemdExecError)
+            .and_then(|output| {
+                if !output.status.success() {
+                    return Err(Error::SystemdShowPidError(
+                        output.status.code(),
+                        String::from_utf8_lossy(output.stderr.as_slice()).to_string(),
+                    ));
+                }
+                String::from_utf8(output.stdout)
+                    .map_err(Error::Utf8Error)
+                    .and_then(|line| {
+                        line.as_str()
+                            .trim()
+                            .rsplit("=")
+                            .next()
+                            .ok_or(Error::SystemdParsePidError)
+                            .and_then(|pid_str| {
+                                pid_str
+                                    .parse::<i32>()
+                                    .map_err(|_| Error::SystemdParsePidError)
+                            })
+                    })
+            })
+            .and_then(|pid| match (pid, force_start) {
+                (0, true) => {
+                    info!("NGINX is not running. Starting it now.");
+                    Command::new("systemctl")
+                        .args(&["start", "nginx.service"])
+                        .status()
+                        .map_err(Error::SystemdExecError)
+                        .and_then(|status| {
+                            if !status.success() {
+                                Err(Error::SystemdStartNginxError(status.code()))
+                            } else {
+                                Ok(())
+                            }
+                        })
+                }
+                (0, false) => {
+                    warn!(
+                        "Unable to reload NGINX: it isn't running and force starting is disabled"
+                    );
+                    Ok(())
+                }
+                (pid, _) => {
+                    debug!("Sending SIGUSR2 to PID={}", pid);
+                    signal::kill(unistd::Pid::from_raw(pid), signal::Signal::SIGUSR2)
+                        .map_err(Error::SendSignalError)?;
+                    debug!("Sending SIGWINCH to PID={}", pid);
+                    signal::kill(unistd::Pid::from_raw(pid), signal::Signal::SIGWINCH)
+                        .map_err(Error::SendSignalError)?;
+                    debug!("Sleeping to allow NGINX to process live update.");
+                    std::thread::sleep(Duration::from_millis(wait_ms));
+                    debug!("Sending SIGQUIT to PID={}", pid);
+                    signal::kill(unistd::Pid::from_raw(pid), signal::Signal::SIGQUIT)
+                        .map_err(Error::SendSignalError)?;
+                    Ok(())
+                }
+            })
+            .unwrap_or_else(|err| {
+                error!("Unable to reload NGINX: {:?}", err);
+            });
     }
 }

--- a/src/vtok_agent/src/config.rs
+++ b/src/vtok_agent/src/config.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 
+use crate::defs;
+
 #[derive(Debug)]
 pub enum Error {
     IoError(std::io::Error),
@@ -15,7 +17,6 @@ pub enum Target {
         path: String,
         user: Option<String>,
         group: Option<String>,
-        force_start: Option<bool>,
     },
 }
 
@@ -65,11 +66,22 @@ pub struct Log {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct Options {
+    #[serde(default = "Options::default_nginx_force_start")]
+    pub nginx_force_start: bool,
+    #[serde(default = "Options::default_nginx_reload_wait_ms")]
+    pub nginx_reload_wait_ms: u64,
+    #[serde(default = "Options::default_sync_interval_secs")]
+    pub sync_interval_secs: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub enclave: Enclave,
     pub tokens: Vec<Token>,
-    pub sync_interval_secs: Option<u64>,
     pub log: Option<Log>,
+    #[serde(default)]
+    pub options: Options,
 }
 
 impl Config {
@@ -90,6 +102,28 @@ impl From<LogLevel> for log::Level {
             LogLevel::Info => log::Level::Info,
             LogLevel::Debug => log::Level::Debug,
             LogLevel::Trace => log::Level::Trace,
+        }
+    }
+}
+
+impl Options {
+    fn default_nginx_force_start() -> bool {
+        defs::DEFAULT_NGINX_FORCE_START
+    }
+    fn default_nginx_reload_wait_ms() -> u64 {
+        defs::DEFAULT_NGINX_RELOAD_WAIT_MS
+    }
+    fn default_sync_interval_secs() -> u64 {
+        defs::DEFAULT_SYNC_INTERVAL_SECS
+    }
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            nginx_force_start: Self::default_nginx_force_start(),
+            nginx_reload_wait_ms: Self::default_nginx_reload_wait_ms(),
+            sync_interval_secs: Self::default_sync_interval_secs(),
         }
     }
 }

--- a/src/vtok_agent/src/main.rs
+++ b/src/vtok_agent/src/main.rs
@@ -32,6 +32,7 @@ pub mod defs {
     pub const DEFAULT_RPC_PORT: u32 = 10000;
     pub const DEFAULT_ENCLAVE_BOOT_TIMEOUT_MS: u64 = 5000;
     pub const DEFAULT_NGINX_FORCE_START: bool = true;
+    pub const DEFAULT_NGINX_RELOAD_WAIT_MS: u64 = 1000;
     pub const DEFAULT_SYNC_INTERVAL_SECS: u64 = 600;
     pub const DEFAULT_TOKEN_REFRESH_INTERVAL_SECS: u64 = 2 * 3600;
     pub const DEFAULT_LOG_LEVEL: log::Level = log::Level::Info;


### PR DESCRIPTION
*Description of changes:*

Changed the nginx config reload procedure from token ping-pong to nginx'
own live-update sequence:
- send SIGUSR2 to master process to spawn new master
- send SIGWINCH to old master process to activate the new master
- send SIGQUIT to old master to signal graceful shutdown

This ensures that, after a token DB update, nginx will correctly open
new PKCS#11 sessions and access the new DB.

Signed-off-by: Dan Horobeanu <dhr@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
