### PR TITLE
nginx: reload after token refresh

### DIFF
--- a/src/vtok_agent/src/agent/mngtok.rs
+++ b/src/vtok_agent/src/agent/mngtok.rs
@@ -204,7 +204,7 @@ impl ManagedToken {
         let db_changed = self.db.update()?;
         let is_online = self
             .enclave
-            .rpc(schema::ApiRequest::DescribeToken {
+            .rpc(&schema::ApiRequest::DescribeToken {
                 label: self.label.clone(),
                 pin: self.pin.clone(),
             })
@@ -220,7 +220,7 @@ impl ManagedToken {
 
                 debug!("Updating token {}", self.label.as_str());
                 self.enclave
-                    .rpc(schema::ApiRequest::UpdateToken {
+                    .rpc(&schema::ApiRequest::UpdateToken {
                         label: self.label.clone(),
                         pin: self.pin.clone(),
                         token: self.to_schema_token()?,
@@ -244,7 +244,7 @@ impl ManagedToken {
                     self.label.as_str()
                 );
                 self.enclave
-                    .rpc(schema::ApiRequest::UpdateToken {
+                    .rpc(&schema::ApiRequest::UpdateToken {
                         label: self.label.clone(),
                         pin: self.pin.clone(),
                         token: self.to_schema_token()?,
@@ -257,7 +257,7 @@ impl ManagedToken {
                 if self.next_refresh <= Instant::now() {
                     info!("Refreshing token {}", self.label.as_str());
                     self.enclave
-                        .rpc(schema::ApiRequest::RefreshToken {
+                        .rpc(&schema::ApiRequest::RefreshToken {
                             label: self.label.clone(),
                             pin: self.pin.clone(),
                             envelope_key: Self::kms_envelope_key()?,
@@ -275,7 +275,7 @@ impl ManagedToken {
             (false, _, _) => {
                 debug!("Adding token {}", self.label.as_str());
                 self.enclave
-                    .rpc(schema::ApiRequest::AddToken {
+                    .rpc(&schema::ApiRequest::AddToken {
                         token: self.to_schema_token()?,
                     })
                     .map_err(Error::EnclaveError)?

--- a/src/vtok_agent/src/agent/mod.rs
+++ b/src/vtok_agent/src/agent/mod.rs
@@ -124,7 +124,7 @@ impl Agent {
                     );
                     broken_list.push(tok.label.clone());
                     self.enclave
-                        .rpc(schema::ApiRequest::RemoveToken {
+                        .rpc(&schema::ApiRequest::RemoveToken {
                             label: tok.label.clone(),
                             pin: tok.pin.clone(),
                         })

--- a/src/vtok_agent/src/config.rs
+++ b/src/vtok_agent/src/config.rs
@@ -48,6 +48,7 @@ pub struct Enclave {
     pub boot_timeout_ms: Option<u64>,
     pub p11kit_port: Option<u32>,
     pub rpc_port: Option<u32>,
+    pub attestation_retry_count: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/vtok_agent/src/enclave.rs
+++ b/src/vtok_agent/src/enclave.rs
@@ -100,7 +100,7 @@ impl P11neEnclave {
         let mut left = Some(self.boot_timeout);
         let poll_us = 100_000_u32;
         while left.is_some() {
-            if let Ok(Ok(_)) = self.rpc(schema::ApiRequest::DescribeDevice) {
+            if let Ok(Ok(_)) = self.rpc(&schema::ApiRequest::DescribeDevice) {
                 return true;
             }
             unsafe {
@@ -118,7 +118,7 @@ impl P11neEnclave {
         self.pid
     }
 
-    pub fn rpc(&self, request: schema::ApiRequest) -> Result<schema::ApiResponse, Error> {
+    pub fn rpc(&self, request: &schema::ApiRequest) -> Result<schema::ApiResponse, Error> {
         VsockStream::connect(VsockAddr {
             cid: self.cid,
             port: self.rpc_port,

--- a/src/vtok_agent/src/main.rs
+++ b/src/vtok_agent/src/main.rs
@@ -37,6 +37,7 @@ pub mod defs {
     pub const DEFAULT_LOG_LEVEL: log::Level = log::Level::Info;
     pub const DEFAULT_LOG_TIMESTAMP: bool = false;
     pub const DEFAULT_ACM_BUCKET: &str = "prod";
+    pub const DEFAULT_ATTESTATION_RETRY_COUNT: usize = 5;
 }
 
 pub mod gdata {

--- a/src/vtok_agent/src/main.rs
+++ b/src/vtok_agent/src/main.rs
@@ -23,7 +23,6 @@ use std::sync::atomic::Ordering;
 
 pub mod defs {
     pub const RUN_DIR: &str = "/run/nitro_enclaves/acm";
-    pub const SWAP_TOKEN_LABEL: &str = "p11ne-swap";
     pub const P11_MODULE_NAME: &str = "p11ne";
 
     pub const DEFAULT_CONFIG_PATH: &str = "/etc/nitro_enclaves/acm.yaml";
@@ -34,7 +33,7 @@ pub mod defs {
     pub const DEFAULT_NGINX_FORCE_START: bool = true;
     pub const DEFAULT_NGINX_RELOAD_WAIT_MS: u64 = 1000;
     pub const DEFAULT_SYNC_INTERVAL_SECS: u64 = 600;
-    pub const DEFAULT_TOKEN_REFRESH_INTERVAL_SECS: u64 = 2 * 3600;
+    pub const DEFAULT_TOKEN_REFRESH_INTERVAL_SECS: u64 = 12 * 3600;
     pub const DEFAULT_LOG_LEVEL: log::Level = log::Level::Info;
     pub const DEFAULT_LOG_TIMESTAMP: bool = false;
     pub const DEFAULT_ACM_BUCKET: &str = "prod";

--- a/src/vtok_rpc/src/transport.rs
+++ b/src/vtok_rpc/src/transport.rs
@@ -23,11 +23,11 @@ pub trait Transport {
     /// Receive an RPC request.
     fn recv_request(&mut self) -> Result<ApiRequest>;
     /// Send an RPC request.
-    fn send_request(&mut self, req: ApiRequest) -> Result<()>;
+    fn send_request(&mut self, req: &ApiRequest) -> Result<()>;
     /// Receive an RPC response.
     fn recv_response(&mut self) -> Result<ApiResponse>;
     /// Send an RPC response.
-    fn send_response(&mut self, resp: ApiResponse) -> Result<()>;
+    fn send_response(&mut self, resp: &ApiResponse) -> Result<()>;
 }
 
 /// RPC transport implementation via a super-simple subset of HTTP.
@@ -160,7 +160,7 @@ impl<S: Read + Write> Transport for HttpTransport<S> {
         })
     }
 
-    fn send_request(&mut self, request: ApiRequest) -> Result<()> {
+    fn send_request(&mut self, request: &ApiRequest) -> Result<()> {
         let body = serde_json::to_vec(&request).map_err(Error::SerdeError)?;
         self.stream
             .write(
@@ -198,7 +198,7 @@ impl<S: Read + Write> Transport for HttpTransport<S> {
         })
     }
 
-    fn send_response(&mut self, response: ApiResponse) -> Result<()> {
+    fn send_response(&mut self, response: &ApiResponse) -> Result<()> {
         let body = serde_json::to_vec(&response).map_err(Error::SerdeError)?;
         self.stream
             .write(

--- a/src/vtok_srv/src/worker.rs
+++ b/src/vtok_srv/src/worker.rs
@@ -51,7 +51,7 @@ where
             });
 
         self.transport
-            .send_response(response)
+            .send_response(&response)
             .map_err(Error::TransportError)
     }
 

--- a/src/vtok_tool/src/main.rs
+++ b/src/vtok_tool/src/main.rs
@@ -125,7 +125,7 @@ fn cmd_raw_rpc<I: Iterator<Item = String>>(mut arg_iter: I) -> Result<(), Error>
         let request = serde_json::from_reader(std::io::stdin())
             .map_err(|_| Error::UsageError(format!("Invalid RPC request")))?;
         transport
-            .send_request(request)
+            .send_request(&request)
             .map_err(Error::TransportError)?;
         let response = transport.recv_response().map_err(Error::TransportError)?;
 


### PR DESCRIPTION
*Description of changes:*

- Changed default token refresh interval to 12h;
- Reload nginx after token refresh;
- Added the mechanism to retry all RPCs that involve attestation
- Added a new config option under enclave.attestation_retry_count,
  allowing the user to set the number of retries;
- Changed the P11Enclave interface to expose specific RPC methods
  instead of the generic `P11Enclave::rpc`;
- Fixed an issue whereby the RPC Transport trait would needlessly require
  ownership of schema::ApiRequest and schema::ApiResponse objects.
  Transport methods now borrow these objects.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
