### PR TITLE
Fix build issues with large UIDs

### DIFF
--- a/env/enclave/Dockerfile
+++ b/env/enclave/Dockerfile
@@ -193,7 +193,7 @@ RUN git clone "https://github.com/aws/aws-nitro-enclaves-sdk-c" \
 RUN [ $USER_ID -eq 0 ] && exit 0; \
     groupadd -g $GROUP_ID $USER; \
     group_name=$(getent group $GROUP_ID | cut -d: -f1) \
-    && useradd -u $USER_ID -m -d "/home/$USER" -g "$group_name" -s /bin/sh $USER \
+    && useradd -l -u $USER_ID -m -d "/home/$USER" -g "$group_name" -s /bin/sh $USER \
     && echo "$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
     && mv /root/.cargo "/home/$USER/.cargo" \
     && mv /root/.rustup "/home/$USER/.rustup" \

--- a/env/parent/Dockerfile
+++ b/env/parent/Dockerfile
@@ -28,7 +28,7 @@ RUN cd /tmp/build \
 RUN [ $USER_ID -eq 0 ] && exit 0; \
     groupadd -g $GROUP_ID "$USER"; \
     group_name=$(getent group $GROUP_ID | cut -d: -f1) \
-    && useradd -u $USER_ID -d "/home/$USER" -g "$group_name" -G docker,ne -s /bin/bash "$USER" \
+    && useradd -l -u $USER_ID -d "/home/$USER" -g "$group_name" -G docker,ne -s /bin/bash "$USER" \
     && chown -R "$USER:$group_name" "$HOME" \
     && chown -R "$USER:$group_name" /var/log/nitro_enclaves /run/nitro_enclaves \
     && echo "$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers


### PR DESCRIPTION
Due to a known docker issue, the build hangs when adding
an user with large UID during build.

As a workaround use useradd with the -l option.

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
