### PR TITLE
p11ne-cli: improve JSON output reporting

### DIFF
--- a/tools/p11ne-cli
+++ b/tools/p11ne-cli
@@ -391,7 +391,7 @@ cmd_init-token() {
     # Execute RPC
     local result
     result=$(execute_rpc "$rpc_request")
-    echo "$result" | jq
+    echo "$result" | jq '.'
 }
 
 # Refresh a token
@@ -434,7 +434,7 @@ cmd_refresh-token() {
     # Execute RPC
     local result
     result=$(execute_rpc "$rpc_request")
-    echo "$result" | jq
+    echo "$result" | jq '.'
 }
 
 # Release a token
@@ -465,7 +465,7 @@ cmd_release-token() {
     # Execute RPC
     local result
     result=$(execute_rpc "$rpc_request")
-    echo "$result" | jq
+    echo "$result" | jq '.'
 }
 
 # Get the device status
@@ -479,7 +479,7 @@ cmd_describe-device() {
     # Execute RPC
     local result
     result=$(execute_rpc "{\"DescribeDevice\": null}")
-    echo "$result" | jq
+    echo "$result" | jq '.'
 }
 
 # Describe a token
@@ -510,7 +510,7 @@ cmd_describe-token() {
     # Execute RPC
     local result
     result=$(execute_rpc "$rpc_request")
-    echo "$result" | jq
+    echo "$result" | jq '.'
 }
 
 main() {


### PR DESCRIPTION
Currently the commands made available by the
p11ne-cli report their output as JSON, by
piping their output through plain `jq`.

This was found to introduce a problem when trying
to process the output in shell scripts (e.g. storing
the output in a shell variable for further processing).
Plain `jq` expects the destination of the JSON
representation to be a terminal.

This commit adds a pretty-print filter to `jq`
(`jq '.'`) such that the output can be processed in
shell scripts as well.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
