### PR TITLE
Support Java PKCS11 KeyStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ tools/devtool simulate-parent
 
 This will spin up a container with p11-kit configured to access the remote
 module exposed by the enclave container via a Unix socket.
-`devtool runparent` starts a BASH shell, so the user can manually test /
+`devtool simulate-parent` starts a BASH shell, so the user can manually test /
 inspect the functionality of the ACM for Nitro Enclaves module; for instance, via
 running `openssl` manually, directed to use the PKCS#11 engine and a URI
 pointing to the pkcs#11 provider module token:

--- a/src/vtok_agent/src/agent/mngtok.rs
+++ b/src/vtok_agent/src/agent/mngtok.rs
@@ -106,6 +106,7 @@ impl DbSource {
                 id: 1,
                 label: "acm-key".to_string(),
                 encrypted_pem_b64: db.encrypted_private_key.clone(),
+                cert_pem: Some(self.cert_pem().unwrap().to_string()),
             }],
             Self::File { db, .. } => db.as_slice().to_vec(),
         }

--- a/src/vtok_common/src/config.rs
+++ b/src/vtok_common/src/config.rs
@@ -21,6 +21,7 @@ pub struct PrivateKey {
     pub encrypted_pem_b64: String,
     pub id: u8,
     pub label: String,
+    pub cert_pem: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/vtok_p11/src/backend/db/mod.rs
+++ b/src/vtok_p11/src/backend/db/mod.rs
@@ -103,7 +103,7 @@ impl Db {
                 let cert = CertInfo {
                     id: key_config.id,
                     label: key_config.label.clone(),
-                    pem: key_config.cert_pem.clone().unwrap(),
+                    pem: key_config.cert_pem.clone().ok_or(Error::GeneralError)?,
                 };
                 objects.push(Object::new_trusted_cert(cert));
             }

--- a/src/vtok_p11/src/backend/db/mod.rs
+++ b/src/vtok_p11/src/backend/db/mod.rs
@@ -99,7 +99,7 @@ impl Db {
                 }
             }
 
-            if !key_config.cert_pem.is_none() {
+            if key_config.cert_pem.is_some() {
                 let cert = CertInfo {
                     id: key_config.id,
                     label: key_config.label.clone(),

--- a/src/vtok_p11/src/backend/db/mod.rs
+++ b/src/vtok_p11/src/backend/db/mod.rs
@@ -40,6 +40,13 @@ pub struct EcKeyInfo {
     pub point_q_x962: Vec<u8>,
 }
 
+#[derive(Clone)]
+pub struct CertInfo {
+    pub pem: String,
+    pub id: pkcs11::CK_BYTE,
+    pub label: String,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum Error {
     GeneralError,
@@ -90,6 +97,15 @@ impl Db {
                     objects.push(Object::new_ec_private_key(info.clone()));
                     objects.push(Object::new_ec_public_key(info));
                 }
+            }
+
+            if !key_config.cert_pem.is_none() {
+                let cert = CertInfo {
+                    id: key_config.id,
+                    label: key_config.label.clone(),
+                    pem: key_config.cert_pem.clone().unwrap(),
+                };
+                objects.push(Object::new_trusted_cert(cert));
             }
         }
 

--- a/src/vtok_rpc/src/api.rs
+++ b/src/vtok_rpc/src/api.rs
@@ -142,6 +142,7 @@ pub mod schema {
             pub encrypted_pem_b64: String,
             pub id: u8,
             pub label: String,
+            pub cert_pem: Option<String>,
         }
 
         #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/vtok_srv/src/worker.rs
+++ b/src/vtok_srv/src/worker.rs
@@ -317,6 +317,7 @@ where
                 encrypted_pem_b64: key.encrypted_pem_b64,
                 id: key.id,
                 label: key.label,
+                cert_pem: key.cert_pem,
             })
         }
         Ok(private_keys)

--- a/tools/devtool
+++ b/tools/devtool
@@ -568,8 +568,8 @@ cmd_simulate-parent() {
     ok_or_die "Build failed."
 
     local ctr_id=$(get_running_container_id "$ENCLAVE_CTR")
-    if [[ -n $ctr_id ]]; then
-        say_warn "Enclave container is not runing. Use \`$0 simulate-enclave\` to start it."
+    if [[ -z $ctr_id ]]; then
+        say_warn "Enclave container is not running. Use \`$0 simulate-enclave\` to start it."
     fi
 
     docker run --rm -it \

--- a/tools/p11ne-db
+++ b/tools/p11ne-db
@@ -17,6 +17,7 @@ Commands:
     --id            <private-key id>
     --label         <private-key label>
     --key-file      <input PEM file>
+    [--cert-file]   <input certificate PEM file>
     --out-file      <output file>
     --kms-key-id    <id of the KMS CMK key used to encrypt the private key>
     --kms-region    <region of the KMS CMK key>
@@ -26,7 +27,9 @@ Commands:
 # Database format converter
 cmd_pack-key() {
 
-    if [ "$#" -ne 12 ]; then
+    local nargs="$#";
+
+    if [ $nargs -ne 12 -a $nargs -ne 14 ]; then
         die "Invalid arguments. Please use \`$0 help\` for help."
     fi
 
@@ -35,6 +38,7 @@ cmd_pack-key() {
             --id) id="$2"; shift ;;
             --label) label="$2"; shift ;;
             --key-file) key_file="$2"; shift ;;
+            --cert-file) cert_file="$2"; shift ;;
             --out-file) out_file="$2"; shift ;;
             --kms-key-id) key_id="$2"; shift ;;
             --kms-region) region="$2"; shift ;;
@@ -42,6 +46,10 @@ cmd_pack-key() {
         esac
         shift
     done
+
+    if [ $nargs -eq 12 -a -n "$cert_file" ]; then
+        die "Invalid arguments. Please use \`$0 help\` for help."
+    fi
 
     # The key file
     if [ ! -f "$key_file" ]; then
@@ -61,12 +69,19 @@ cmd_pack-key() {
     enc_key=$(aws kms encrypt --key-id $key_id --plaintext "$key" --region $region --query CiphertextBlob --output text)
     ok_or_die "Failed to encrypt the key"
 
+    # Read the cert (optional)
+    local cert
+    if [ -n "$cert_file" -a -f "$cert_file" ]; then
+        cert=$(<"$cert_file")
+    fi
+
     local out_data
     out_data=$( jq -Rn \
             --arg a "$enc_key" \
             --arg b "$id" \
             --arg c "$label" \
-            '[{encrypted_pem_b64: $a, id: $b | tonumber, label: $c}]' )
+            --arg d "$cert"
+            '[{encrypted_pem_b64: $a, id: $b | tonumber, label: $c, cert_pem: $d}] | with_entries( select( .value != "" ) ) ')
     ok_or_die "Cannot format the input key."
 
     echo "$out_data" > "$out_file.db"


### PR DESCRIPTION
*Issue # , if available:*
Fix #39

*Description of changes:*
Support optional certificate accessible via pkcs11 under same `CKA_ID` as private key to help address Java keystore requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
