### PR TITLE
p11/crypto: fix aarch64 build

### DIFF
--- a/src/vtok_p11/src/crypto/mod.rs
+++ b/src/vtok_p11/src/crypto/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::pkcs11;
@@ -232,7 +232,7 @@ fn bignum_to_vec(bn: *const ffi::BIGNUM) -> Result<Vec<u8>> {
     }
     let mut ret = vec![0u8; len as usize];
 
-    let written = unsafe { ffi::BN_bn2bin(bn, ret.as_mut_ptr() as *mut i8) };
+    let written = unsafe { ffi::BN_bn2bin(bn, ret.as_mut_ptr() as *mut _) };
     if ret.len() != written as usize {
         return Err(Error::GeneralError);
     }


### PR DESCRIPTION
Some aarch64 platforms complain about char vs unsigned char
types. Make this an inferred cast to unlock aarch64 builds.

--> src/vtok_p11/src/crypto/mod.rs:274:47
    |
274 |   ... { ffi::BN_bn2bin(bn, ret.as_mut_ptr() as \
			*mut i8) };
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>
