### PR TITLE
p11ne: Increase support for up to 128 ACM certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ be mostly transparent to the developer, and employed via the omnitool at
 
 The user guide for the ACM for Nitro Enclaves can be found at https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-refapp.html.
 
+# Managed tokens
+
+Each token can store an end-entity private key and its associated ACM certificate chain. Up to 128 SSL/TLS X.509 ACM certificates can be managed via provisioned tokens by the nitro-enclaves-acm service.
+Configuration options can be found in the `/etc/nitro_enclaves/acm.yaml` post service installation.
+
 ## Design Overview
 
 ACM for Nitro Enclaves is a PKCS#11 provider (i.e. a dynamic library exposing the
@@ -148,7 +153,7 @@ validate the PKCS#11 module functionality using openssl or OpenSC pkcs11-tool.
 
 Build the testhelper binary:
 ```bash
-$ cd tests/helpers && cargo build release
+$ cd tests/helpers && cargo build --release
 
 $ cd - && cp build/target/release/testhelpers ./tests
 ```

--- a/src/vtok_common/src/lib.rs
+++ b/src/vtok_common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate libc;
@@ -16,7 +16,7 @@ pub mod defs {
     /// PKCS#11 provider description, as reported by vtok_p11.
     pub const DEVICE_DESCRIPTION: &str = "p11ne";
     /// Maximum number of slots/tokens exposed by our PKCS#11 provider.
-    pub const DEVICE_MAX_SLOTS: usize = 8;
+    pub const DEVICE_MAX_SLOTS: usize = 128;
 
     /// PKCS#11 provider slot description.
     pub const SLOT_DESCRIPTION: &str = "p11ne-slot";


### PR DESCRIPTION
Users can populate tokens via the acm.yaml configuration
file with up to 128 ACM private key-certificate pairs.

This serves for some use cases where multiple domains
are served from the same EC2 instance.

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>