### PR TITLE
agent: Don't restart Nginx, only reload

### DIFF
--- a/src/vtok_agent/src/agent/mod.rs
+++ b/src/vtok_agent/src/agent/mod.rs
@@ -225,16 +225,8 @@ impl PostSyncAction {
                     Ok(())
                 }
                 (pid, _) => {
-                    debug!("Sending SIGUSR2 to PID={}", pid);
-                    signal::kill(unistd::Pid::from_raw(pid), signal::Signal::SIGUSR2)
-                        .map_err(Error::SendSignalError)?;
-                    debug!("Sending SIGWINCH to PID={}", pid);
-                    signal::kill(unistd::Pid::from_raw(pid), signal::Signal::SIGWINCH)
-                        .map_err(Error::SendSignalError)?;
-                    debug!("Sleeping to allow NGINX to process live update.");
-                    std::thread::sleep(Duration::from_millis(wait_ms));
-                    debug!("Sending SIGQUIT to PID={}", pid);
-                    signal::kill(unistd::Pid::from_raw(pid), signal::Signal::SIGQUIT)
+                    debug!("Sending SIGHUP to PID={}", pid);
+                    signal::kill(unistd::Pid::from_raw(pid), signal::Signal::SIGHUP)
                         .map_err(Error::SendSignalError)?;
                     Ok(())
                 }


### PR DESCRIPTION
So far, we issued multiple signals to Nginx in succession when DEFAULT_TOKEN_REFRESH_INTERVAL_SECS elapsed to potentially reload the certificate:

  1) SIGUSR2 - Upgrade nginx executable on the fly
  2) SIGWINCH - Shut down gracefully worker processes
  3) SIGQUIT - Shut down gracefully

That meant every time, we eventually shut down the full Nginx server which then may or may not get restarted by systemd.

All of the above is unnecessary. We merely need to tell Nginx that a new configuration arrived through the SIGHUB signal at which point it will wind down any active worker and start new ones with the new configuration, including new certificate.

So let's switch to a single SIGHUB signal instead.