### PR TITLE
Upgrade of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "cc"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,9 +52,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linked-hash-map"
@@ -79,25 +73,32 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "nix"
-version = "0.20.2"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
+ "pin-utils",
+ "static_assertions",
 ]
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -165,6 +166,12 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,18 +102,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -126,18 +126,18 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -175,13 +175,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -189,10 +189,10 @@ name = "testhelpers"
 version = "0.1.0"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.1"
+name = "unicode-ident"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vtok_agent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "lazy_static"
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,6 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -64,12 +58,9 @@ checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if 0.1.10",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memoffset"
@@ -87,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
  "pin-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linked-hash-map"

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Here is the general flow of a parent instance crypto operation:
 
 | name                       | version              | link                                              |
 |----------------------------|----------------------|---------------------------------------------------|
-| aws-lc                     | v1.0.2               | https://github.com/awslabs/aws-lc/                |
-| aws-nitro-enclaves-sdk     | v0.3.0               | https://github.com/aws/aws-nitro-enclaves-sdk-c   |
-| s2n-tls                    | v1.3.20              | https://github.com/aws/s2n-tls.git                |
+| aws-lc                     | v1.12.0              | https://github.com/awslabs/aws-lc/                |
+| aws-nitro-enclaves-sdk     | v0.4.1               | https://github.com/aws/aws-nitro-enclaves-sdk-c   |
+| s2n-tls                    | v1.3.46              | https://github.com/aws/s2n-tls.git                |
 | aws-c-common               | v0.8.0               | https://github.com/awslabs/aws-c-common           |
 | aws-c-io                   | v0.11.0              | https://github.com/awslabs/aws-c-io               |
 | aws-c-compression          | v0.2.14              | https://github.com/awslabs/aws-c-compression      |
@@ -61,7 +61,7 @@ Here is the general flow of a parent instance crypto operation:
 | aws-c-cal                  | v0.5.18              | https://github.com/awslabs/aws-c-cal              |
 | aws-c-auth                 | v0.6.15              | https://github.com/awslabs/aws-c-auth             |
 | aws-c-sdkutils             | v0.1.2               | https://github.com/awslabs/aws-c-sdkutils         |
-| aws-nitro-enclaves-nsm-api | v0.2.1               | https://github.com/aws/aws-nitro-enclaves-nsm-api |
+| aws-nitro-enclaves-nsm-api | v0.4.0               | https://github.com/aws/aws-nitro-enclaves-nsm-api |
 | json-c                     | json-c-0.16-20220414 | https://github.com/json-c/json-c                  |
 
 `devtool` sets up two containers: one for emulating the enclave environment,

--- a/env/enclave/Dockerfile
+++ b/env/enclave/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2020-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This Docker file sets up the development environment for the eVault components
@@ -41,7 +41,7 @@ RUN mkdir -p /build
 WORKDIR /build
 
 # Build AWS libcrypto
-ENV AWS_LC_VER="v1.0.2"
+ENV AWS_LC_VER="v1.12.0"
 RUN git clone "https://github.com/awslabs/aws-lc.git" \
     && cd aws-lc \
     && git reset --hard $AWS_LC_VER \
@@ -57,7 +57,7 @@ RUN git clone "https://github.com/awslabs/aws-lc.git" \
     && ldconfig /usr/lib
 
 # AWS-S2N
-ENV AWS_S2N_VER="v1.3.20"
+ENV AWS_S2N_VER="v1.3.46"
 RUN git clone https://github.com/aws/s2n-tls.git \
     && cd s2n-tls \
     && git reset --hard $AWS_S2N_VER \
@@ -178,7 +178,7 @@ RUN git clone https://github.com/json-c/json-c.git \
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN
 
 # NSM LIB
-ENV AWS_NE_NSM_API_VER="v0.2.1"
+ENV AWS_NE_NSM_API_VER="v0.4.0"
 RUN git clone "https://github.com/aws/aws-nitro-enclaves-nsm-api" \
     && cd aws-nitro-enclaves-nsm-api \
     && git reset --hard $AWS_NE_NSM_API_VER \
@@ -187,7 +187,7 @@ RUN git clone "https://github.com/aws/aws-nitro-enclaves-nsm-api" \
     && mv target/release/nsm.h /usr/include/
 
 # AWS Nitro Enclaves SDK
-ENV AWS_NE_SDK_VER="v0.3.0"
+ENV AWS_NE_SDK_VER="v0.4.1"
 RUN git clone "https://github.com/aws/aws-nitro-enclaves-sdk-c" \
     && cd aws-nitro-enclaves-sdk-c \
     && git reset --hard $AWS_NE_SDK_VER \

--- a/src/vtok_agent/Cargo.toml
+++ b/src/vtok_agent/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
-log = { version = "0.4.8", features = ["std"] }
+log = { version = "0.4.20", features = ["std"] }
 nix = "0.26"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/src/vtok_agent/Cargo.toml
+++ b/src/vtok_agent/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2020-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["std"] }
-nix = "0.20"
+nix = "0.26"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1.0"

--- a/src/vtok_p11/Cargo.toml
+++ b/src/vtok_p11/Cargo.toml
@@ -17,5 +17,5 @@ serde_json = "1.0"
 vtok_common = { path = "../vtok_common" }
 
 [dependencies.log]
-version = "0.4.8"
+version = "0.4.20"
 features = ["std"]

--- a/src/vtok_srv/Cargo.toml
+++ b/src/vtok_srv/Cargo.toml
@@ -7,7 +7,7 @@ description = "Nitro vToken provisioning server"
 
 [dependencies]
 libc = "0.2"
-base64 = "0.12"
+base64 = "0.21"
 vtok_common = { path = "../vtok_common" }
 vtok_rpc = { path = "../vtok_rpc" }
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2020-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dev container versions. These should be incremented every time a change is made to their
@@ -30,7 +30,7 @@ EVBIN_CLI=p11ne-cli
 EVBIN_INIT=p11ne-init
 EVBIN_P11_MOD=libvtok_p11.so
 
-P11NE_PARENT_RUST_TOOLCHAIN=1.47.0
+P11NE_PARENT_RUST_TOOLCHAIN=1.63.0
 P11NE_ENCLAVE_RUST_TOOLCHAIN=1.63.0
 
 USAGE="\


### PR DESCRIPTION
*Description of changes:*
* Update dependencies raised by dependabot
* Update AWS dependencies: `aws-lc`, `ne-sdk`, `nsm-lib`, etc.
* Update Rust version to 1.63

Testing was done with https://github.com/aws/aws-nitro-enclaves-acm/blob/main/tests/testtool.
Results:
```
$ ./tests/testtool openssl --kms-key-id ****** --kms-region ******
Running Sign&verify tests
Running RSA-PSS Sign&Verify tests using openssl
test_openssl_digestsignverify_rsapss_rsa1024_0B_0_sha1
test_openssl_digestsignverify_rsapss_rsa1024_0B_0_sha1 ............... PASSED
...
test_x509_noroot_chain ............................................... PASSED
test_x509_invalid_chain
test_x509_invalid_chain .............................................. PASSED

744 tests passed, 0 tests failed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
