### PR TITLE
AL2023 test and helper script fixes

### DIFF
--- a/tests/testtool
+++ b/tests/testtool
@@ -275,7 +275,6 @@ openssl_ref_digestsign_rsapss() {
         -sign "$(get_key_file $keylabel private)" \
         -sigopt rsa_padding_mode:pss \
         -sigopt "rsa_pss_saltlen:$saltlen" \
-        -sigopt "digest:$digest" \
         -out "$outsign" "$input"
 
     return $?
@@ -292,7 +291,6 @@ openssl_ref_digestverify_rsapss() {
         -verify "$(get_key_file $keylabel public)" \
         -sigopt rsa_padding_mode:pss \
         -sigopt "rsa_pss_saltlen:$saltlen" \
-        -sigopt "digest:$digest" \
         -signature "$sign" "$input"
 
     return $?
@@ -760,7 +758,7 @@ provision_key() {
     done
 
     # Initialize a token with one key type
-    p11ne-db pack-key --id 1 --label testkey --key-file "$(get_key_file "$keylabel" private)" --out-file "$KEY_DB_DIR/$keylabel" --kms-key-id "$key_id" --kms-region "$region"
+    p11ne-db pack-key --id 1 --label "$keylabel" --key-file "$(get_key_file "$keylabel" private)" --out-file "$KEY_DB_DIR/$keylabel" --kms-key-id "$key_id" --kms-region "$region"
     ok_or_die "Cannot pack p11ne token test key."
 
     p11ne-cli init-token --key-db "$KEY_DB_DIR/$keylabel.db" --label "$TOKEN_LABEL" --pin "$PIN" > /dev/null 2>&1
@@ -785,7 +783,7 @@ provision_key_w_cert() {
     done
 
 	 # Initialize a token with one key type
-    p11ne-db pack-key --id 1 --label testkey --key-file "$(get_cert_file_key "$keylabel")" --cert-file "$(get_cert_file "$keylabel")" \
+    p11ne-db pack-key --id 1 --label "$keylabel" --key-file "$(get_cert_file_key "$keylabel")" --cert-file "$(get_cert_file "$keylabel")" \
 				--out-file "$KEY_DB_DIR/$keylabel" --kms-key-id "$key_id" --kms-region "$region"
     ok_or_die "Cannot pack p11ne token test key."
 

--- a/tools/p11ne-db
+++ b/tools/p11ne-db
@@ -65,8 +65,17 @@ cmd_pack-key() {
     which aws > /dev/null
     ok_or_die "aws cli is not present on this machine. Please install the aws cli and try again."
 
+     # Fetch AWS CLI version
+    local aws_cli_ver
+    aws_cli_ver=$(aws --version 2>&1 | cut -d " " -f1 | cut -d "/" -f2 | cut -d "." -f1)
+
     #encrypt with kms - the result is the Base64 representation of the cyphertext
-    enc_key=$(aws kms encrypt --key-id $key_id --plaintext "$key" --region $region --query CiphertextBlob --output text)
+    enc_cmd="aws kms encrypt --key-id $key_id --plaintext \"$key\" --region $region --query CiphertextBlob --output text"
+    if [[ $aws_cli_ver -gt 1 ]]; then
+        # Specify explicit binary format for aws cli v2
+        enc_cmd+=" --cli-binary-format raw-in-base64-out"
+    fi
+    enc_key=$(eval "$enc_cmd")
     ok_or_die "Failed to encrypt the key"
 
     # Read the cert (optional)


### PR DESCRIPTION
*Description of changes:*
Some of the test and helper scripts don't work on AL2023 because of newer versions of `aws cli` and `openssl`.
Necessary fixes:
* p11ne-db: use explicit raw-in-base64-out binary input format
* testtool: adjust testtool for al2023

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
