### PR TITLE
[feat] Support retrieving instance role ARN from an EC2 instance tag

### DIFF
--- a/src/vtok_agent/src/imds.rs
+++ b/src/vtok_agent/src/imds.rs
@@ -186,7 +186,10 @@ impl ImdsCache {
     }
 
     fn fetch_instance_tag(token: &str, tag_key: &str) -> Result<String, Error> {
-        Self::fetch(format!("/latest/meta-data/tags/instance/{}", tag_key).as_str(), token)
+        Self::fetch(
+            format!("/latest/meta-data/tags/instance/{}", tag_key).as_str(),
+            token,
+        )
     }
 
     fn fetch_role_name(token: &str) -> Result<String, Error> {
@@ -195,7 +198,7 @@ impl ImdsCache {
 
     fn fetch_role_arn(token: &str) -> Result<String, Error> {
         if let Some(role_arn) = Self::fetch_instance_tag(token, INSTANCE_ROLE_ARN_TAG) {
-            return Ok(role_arn)
+            return Ok(role_arn);
         }
 
         let role_name = Self::fetch_role_name(token)?;

--- a/src/vtok_agent/src/imds.rs
+++ b/src/vtok_agent/src/imds.rs
@@ -197,7 +197,7 @@ impl ImdsCache {
     }
 
     fn fetch_role_arn(token: &str) -> Result<String, Error> {
-        if let Some(role_arn) = Self::fetch_instance_tag(token, INSTANCE_ROLE_ARN_TAG) {
+        if let Ok(role_arn) = Self::fetch_instance_tag(token, INSTANCE_ROLE_ARN_TAG) {
             return Ok(role_arn);
         }
 


### PR DESCRIPTION
*Issue #, if available:* #15, #55, #129

*Description of changes:*

In VPCs without a NAT Gateway, the current code will fail to resolve IAM instance roles that have a `Path` a because the Path is not returned from the IMDS. This code will look for a specific EC2 Instance Role tag (`InstanceRoleArn`) that will be used instead of calling `iam:GetRole` (which will fail in VPCs without NAT Gateways).

The risk of someone defining another IAM role and being able to download the private certificate should be mitigated by the fact that [AssociateEnclaveCertificateIamRole](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateEnclaveCertificateIamRole.html) wouldn't have been called allowing the IAM role to download the certificate from the S3 bucket.

`sts:GetCallerIdentity` also doesn't work for this use case since it returns the assumed role ARN, not the IAM role ARN:

```json
{
    "UserId": "AROAXXXXXXXXXXXX:i-XXXXXXXXXXX",
    "Account": "123456789012",
    "Arn": "arn:aws:sts::123456789012:assumed-role/myrole-rInstanceRole-dSmAJj6Hqvw8/i-XXXXXXXXXXX"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
