### PR TITLE
restart nginx when nitro-enclaves-acm is restarted

### DIFF
--- a/src/vtok_agent/src/util.rs
+++ b/src/vtok_agent/src/util.rs
@@ -14,6 +14,18 @@ pub enum SleepError {
     UserExit,
 }
 
+#[derive(Debug)]
+pub enum SystemdError {
+    SendSignalError(nix::Error),
+    ExecError(std::io::Error),
+    StartError(Option<i32>),
+    ParsePidError,
+    ShowPidError(Option<i32>, String),
+    OverrideError,
+    ReloadError,
+    StreamError(std::string::FromUtf8Error),
+}
+
 pub fn interruptible_sleep(dur: Duration) -> Result<(), SleepError> {
     let wake_time = Instant::now() + dur;
     loop {


### PR DESCRIPTION
*Description of changes:*
To ensure consistent state, **nginx** should be restarted instead of just reloading its configuration when the **nitro-enclaves-acm** service is restarted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
