### PR TITLE
Speed up builds for the token provider library

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -498,6 +498,7 @@ cmd_build() {
         ensure_enclave_ctr
         docker run --rm $interactive \
             -v "$EVAULT_SRC_DIR:$CTR_SRC_DIR" \
+            -v "$EVAULT_BUILD_DIR/cargo-registry:$CTR_HOME/.cargo/registry" \
             --workdir "$CTR_SRC_DIR" \
             "$ENCLAVE_CTR_IMG" \
             cargo build "${cargo_args[@]}" --lib


### PR DESCRIPTION
*Description of changes:*
This commit mounts the cargo registry under the build/ folder, which prevents the registry from being recreated for each build. By caching the registry, subsequent builds will be faster as cargo won't need to download dependencies from scratch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
