### PR TITLE
Implement an internal renewal mechanism for token refresh operations

### DIFF
--- a/src/vtok_agent/src/agent/mngtok.rs
+++ b/src/vtok_agent/src/agent/mngtok.rs
@@ -477,7 +477,8 @@ impl ManagedToken {
                         httpd::HttpdService::write_tls_entries(
                             &path, uid, gid, &key_uri, cert_path,
                         )?;
-                        None
+
+                        restart_hint.then(|| PostSyncAction::RestartHttpd)
                     }
                 };
                 Ok(post_action)

--- a/src/vtok_agent/src/util.rs
+++ b/src/vtok_agent/src/util.rs
@@ -23,7 +23,6 @@ pub enum SystemdError {
     ParsePidError,
     ShowPidError(Option<i32>, String),
     OverrideError,
-    ReloadError,
     StreamError(std::string::FromUtf8Error),
 }
 
@@ -125,8 +124,4 @@ pub fn service_start(service_name: &str) -> Result<(), SystemdError> {
 
 pub fn service_restart(service_name: &str) -> Result<(), SystemdError> {
     service_exec("restart", service_name)
-}
-
-pub fn systemd_reload() -> Result<(), SystemdError> {
-    service_exec("daemon-reload", "-f")
 }

--- a/src/vtok_common/src/config.rs
+++ b/src/vtok_common/src/config.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 use serde_json;
+use std::fs;
 use std::fs::OpenOptions;
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
+use std::time::SystemTime;
 
 use crate::defs;
 use crate::util;
@@ -75,6 +77,14 @@ impl Config {
         serde_json::to_writer(BufWriter::new(file), &device).map_err(Error::SerdeError)?;
 
         Ok(())
+    }
+
+    /// Get the modification time of the config file
+    pub fn modification_time() -> Result<SystemTime, Error> {
+        fs::metadata(defs::DEVICE_CONFIG_PATH)
+            .map_err(Error::IoError)?
+            .modified()
+            .map_err(Error::IoError)
     }
 
     /// Load the config in read-only mode.

--- a/src/vtok_p11/src/api/mod.rs
+++ b/src/vtok_p11/src/api/mod.rs
@@ -55,8 +55,8 @@ macro_rules! lock_session_mut {
         let $sess_arc;
         let mut $session;
         {
-            lock_device!(guard, device);
-            $sess_arc = device.session($handle);
+            lock_device_mut!(guard, device);
+            $sess_arc = device.session_mut($handle);
             $session = match $sess_arc {
                 Some(ref sess) => sess.lock().unwrap(),
                 None => return crate::pkcs11::CKR_SESSION_HANDLE_INVALID,

--- a/src/vtok_p11/src/backend/device.rs
+++ b/src/vtok_p11/src/backend/device.rs
@@ -120,6 +120,16 @@ impl Device {
             .and_then(|token| token.session(handle))
     }
 
+    pub fn session_mut(&mut self, handle: pkcs11::CK_SESSION_HANDLE) -> Option<Arc<Mutex<Session>>> {
+        let slot_id = *self.session_slot_map.get(&handle)?;
+
+        //todo: modify slots if necessary
+        match self.token(slot_id) {
+            Ok(token) => token.session(handle),
+            Err(_) => None,
+        }
+    }
+
     pub fn login(&mut self, session_handle: pkcs11::CK_SESSION_HANDLE, pin: &str) -> Result<()> {
         let slot_id = *self
             .session_slot_map

--- a/src/vtok_p11/src/backend/slot.rs
+++ b/src/vtok_p11/src/backend/slot.rs
@@ -56,4 +56,8 @@ impl Slot {
     pub fn token_mut(&mut self) -> Option<&mut Token> {
         self.token.as_mut().filter(|tok| !tok.has_expired())
     }
+
+    pub fn token_unchecked_mut(&mut self) -> Option<&mut Token> {
+        self.token.as_mut()
+    }
 }

--- a/src/vtok_p11/src/backend/token.rs
+++ b/src/vtok_p11/src/backend/token.rs
@@ -106,6 +106,15 @@ impl Token {
         util::time::monotonic_secs() > self.expiry_ts
     }
 
+    pub fn refresh(&mut self, new_expiry_ts: u64) {
+        let needs_refresh = new_expiry_ts != self.expiry_ts;
+
+        if needs_refresh {
+            trace!("Refreshing token: {} with new expiry_ts: {}.", self.label, new_expiry_ts);
+            self.expiry_ts = new_expiry_ts;
+        }
+    }
+
     pub fn open_session(&mut self, handle: pkcs11::CK_SESSION_HANDLE) -> Result<()> {
         if self.sessions.len() >= defs::TOKEN_MAX_SESSIONS as usize {
             return Err(Error::SessionCount);


### PR DESCRIPTION
*Description of changes:*
Refreshing tokens through webserver reloads can lead to performance bottlenecks and other issues. This new approach aims to move the refresh logic into the enclave, enabling more efficient and optimized token refreshing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
