### PR TITLE
agent: Populate systemd config override when restarting

### DIFF
--- a/src/vtok_agent/src/main.rs
+++ b/src/vtok_agent/src/main.rs
@@ -29,8 +29,6 @@ pub mod defs {
     pub const SERVICE_HTTPD: &str = "httpd";
     pub const HTTPD_OVERRIDE_DATA: &str =
         "[Service]\nType=forking\nExecStart=\nExecStart=/usr/sbin/httpd $OPTIONS -k start\n";
-    pub const HTTPD_OVERRIDE_DIR: &str = "/etc/systemd/system/httpd.service.d/";
-    pub const HTTPD_OVERRIDE_FILE: &str = "/etc/systemd/system/httpd.service.d/httpd.conf";
 
     pub const DEFAULT_CONFIG_PATH: &str = "/etc/nitro_enclaves/acm.yaml";
     pub const DEFAULT_EIF_PATH: &str = "/usr/share/nitro_enclaves/p11ne/p11ne.eif";

--- a/src/vtok_agent/src/util.rs
+++ b/src/vtok_agent/src/util.rs
@@ -118,6 +118,20 @@ fn service_exec(arg1: &str, arg2: &str) -> Result<(), SystemdError> {
         })
 }
 
+pub fn reload_systemd_daemon() -> Result<(), SystemdError> {
+    Command::new("systemctl")
+        .args(&["daemon-reload"])
+        .status()
+        .map_err(SystemdError::ExecError)
+        .and_then(|status| {
+            if !status.success() {
+                Err(SystemdError::StartError(status.code()))
+            } else {
+                Ok(())
+            }
+        })
+}
+
 pub fn service_start(service_name: &str) -> Result<(), SystemdError> {
     service_exec("start", service_name)
 }


### PR DESCRIPTION
```
agent: Populate systemd config override when restarting

On AL2 there is a known bug which prevents httpd from working correctly
with PKCS#11 when it is started with -DFOREGROUND option. This option is
set by default in the sample systemd service which gets installed
alongside httpd.

In order to mitigate this problem, override the config explicitly in the
agent code: it was done in this way before until the commit
"c35f99b vtok_agent: Decouple webserver reload from agent" accidentally
removed the httpd systemd configuration code.

So, introduce a function which allows dynamic reconfiguration of the
web-server systemd service when executing post-sync actions. Define the
config for HTTPD (there is already a const string with the required
config in the code).

Since we need to reload the systemd daemon after putting a new config
override, introduce a method to do so.

Clean up unused HTTPD configuration constants.
```