### PR TITLE
Fix build process

### DIFF
--- a/env/enclave/Dockerfile
+++ b/env/enclave/Dockerfile
@@ -8,7 +8,7 @@
 #       source container will start from scratch, cherry-picking only its
 #       required run-time dependencies from here.
 
-FROM alpine:3.16
+FROM public.ecr.aws/docker/library/alpine:3.16
 
 ARG USER
 ARG USER_ID

--- a/tools/devtool
+++ b/tools/devtool
@@ -30,8 +30,7 @@ EVBIN_CLI=p11ne-cli
 EVBIN_INIT=p11ne-init
 EVBIN_P11_MOD=libvtok_p11.so
 
-P11NE_PARENT_RUST_TOOLCHAIN=1.60.0
-P11NE_ENCLAVE_RUST_TOOLCHAIN=1.63.0
+P11NE_RUST_TOOLCHAIN=${RUST_TOOLCHAIN:-1.71.0}
 
 USAGE="\
 $MY_NAME
@@ -232,7 +231,7 @@ build_parent_ctr() {
         --build-arg USER=$(whoami) \
         --build-arg USER_ID=$(id -u) \
         --build-arg GROUP_ID=$(id -g) \
-        --build-arg RUST_TOOLCHAIN="$P11NE_PARENT_RUST_TOOLCHAIN" \
+        --build-arg RUST_TOOLCHAIN="$P11NE_RUST_TOOLCHAIN" \
         --build-arg CTR_HOME="$CTR_HOME" \
         "$ctx_dir"
 }
@@ -245,7 +244,7 @@ build_enclave_ctr() {
         --build-arg USER=$(whoami) \
         --build-arg USER_ID=$(id -u) \
         --build-arg GROUP_ID=$(id -g) \
-        --build-arg RUST_TOOLCHAIN="$P11NE_ENCLAVE_RUST_TOOLCHAIN" \
+        --build-arg RUST_TOOLCHAIN="$P11NE_RUST_TOOLCHAIN" \
         --build-arg CTR_HOME="$CTR_HOME" \
         "$EVAULT_SRC_DIR/env/enclave"
 }


### PR DESCRIPTION
Currently, the project can't be build with rustc 1.63 due to the fact that some of the dependencies of aws-nitro-enclaves-nsm-api rely on the newer compiler versions. It generates the following errors:

error: package `once_cell v1.21.3` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.63.0
error: package `serde_bytes v0.11.17` cannot be built because it requires rustc 1.68 or newer, while the currently active rustc version is 1.63.0

Bump the version to 1.71, as specified in the aws-nitro-enclaves-nsm-api Config.toml to be able to build this subproject.

Also, since public docker hub has a pull rate limit, use public AWS ECR in order to avoid build failures if there were too many build attempts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
