### PR TITLE
cdk: Fix nginx-conf.sh configuration for AL2023 2023.7 release

### DIFF
--- a/cdk/src/assets/user-data-scripts/AL2023/nginx-conf.sh
+++ b/cdk/src/assets/user-data-scripts/AL2023/nginx-conf.sh
@@ -15,8 +15,8 @@ sudo sed -i '/ssl_certificate/d; /ssl_certificate_key/d; /ssl_ciphers/d' /etc/ng
 sudo sed -i '/ssl_session_timeout/a\        ssl_protocols TLSv1.2;' /etc/nginx/nginx.conf
 sudo sed -i '/# Load configuration files for the default server block./a\        include "/etc/pki/nginx/nginx-acm.conf";' /etc/nginx/nginx.conf
 
-# Edit the OpenSSL configuration /etc/pki/tls/openssl.cnf
-sudo sed -i '/ssl_conf = ssl_module/a\engines = engine_section\n\n[engine_section]\npkcs11 = pkcs11_section\n\n[ pkcs11_section ]\nengine_id = pkcs11\ninit = 1' /etc/pki/tls/openssl.cnf
+# Edit the OpenSSL configuration in /etc/pki/tls/openssl.cnf through /etc/pki/tls/openssl.d/openssl-acm.cnf
+sudo sh -c "echo -e '[openssl_init]\nengines = engine_section\n\n[engine_section]\npkcs11 = pkcs11_section\n\n[pkcs11_section]\nengine_id = pkcs11\ninit = 1' >> /etc/pki/tls/openssl.d/openssl-acm.cnf"
 
 # Start the ACM for Nitro Enclaves service
 sudo systemctl start nitro-enclaves-acm.service


### PR DESCRIPTION
*Description of changes:*
As pointed out by @jplock , the latest AL2023 2023.7 release made changes to the `/etc/pki/tls/openssl.cnf` file that broke the line at https://github.com/aws/aws-nitro-enclaves-acm/blob/main/cdk/src/assets/user-data-scripts/AL2023/nginx-conf.sh#L19

Instead of modifying the `openssl.cnf` file directly, this change creates a new file `/etc/pki/tls/openssl.d/openssl-acm.cnf` which is included in the main `openssl.cnf` file. The new `openssl-acm.cnf` file contains the necessary configuration for the ACM use case.

This more generic solution should be robust against future changes to `openssl.cnf`, as the ACM-specific configuration is isolated in a separate file.

*Testing done:*

I have tested the changes on a new AL2023 instance with NGINX and confirmed that the ACM for Nitro enclaves is now correctly configured with OpenSSL and works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.